### PR TITLE
Fix Docker push

### DIFF
--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-VERSION=$(npm run version --silent)
+VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
 IMAGE_NAME=registry.tradeshift.com/http-mockserver:$VERSION
 docker build -t $IMAGE_NAME .
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "start": "./bin/http-mockserver.js",
     "debug": "node --inspect --debug-brk src/server/index.js",
     "lint": "eslint ./src",
-    "test": "./test.sh",
-    "version": "echo $npm_package_version"
+    "test": "./test.sh"
   },
   "bin": {
     "http-mockserver": "./bin/http-mockserver.js"


### PR DESCRIPTION
Docker push is broken since npm is not available outside docker. Bash to the rescue.
@Tradeshift/collaboration 
