### PR TITLE
New Docker registry

### DIFF
--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
-IMAGE_NAME=registry.tradeshift.com/http-mockserver:$VERSION
+IMAGE_NAME=docker.tradeshift.net/http-mockserver:$VERSION
 docker build -t $IMAGE_NAME .
 
 docker push $IMAGE_NAME

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-IMAGE_NAME=registry.tradeshift.com/http-mockserver:$(git rev-parse HEAD)
+IMAGE_NAME=docker.tradeshift.net/http-mockserver:$(git rev-parse HEAD)
 docker build -t $IMAGE_NAME .
 
 docker run $IMAGE_NAME npm test


### PR DESCRIPTION
We need to move all components from the old Docker registry "registry.tradeshift.com" to "docker.tradeshift.net".
This PR will migrate http-mockserver.