### PR TITLE
Make "clear"-method static

### DIFF
--- a/__tests__/mockClient.test.js
+++ b/__tests__/mockClient.test.js
@@ -1,9 +1,9 @@
 const Q = require('q');
 const request = Q.denodeify(require('request'));
-const MockClient = require('../src/client/Client');
 const MOCKSERVER_URI = 'localhost:3000';
+const MockClient = require('../src/client/Client')(MOCKSERVER_URI);
 const MOCKED_HOST_URI = 'http://localhost:4000';
-const mockClient = new MockClient(4000, MOCKSERVER_URI);
+const mockClient = new MockClient(4000);
 
 describe('when adding routes on the same uri', () => {
 	it('should return first response when route is added once', done => {
@@ -63,7 +63,7 @@ describe('clean', () => {
 	});
 
 	it('should not be possible to call the route after it has been cleared', done => {
-		mockClient.clear()
+		MockClient.clearAll()
 
 		// requests are cleared
 		.then(() => mockClient.getRequests())
@@ -81,4 +81,5 @@ describe('clean', () => {
 	});
 });
 
-afterEach(() => mockClient.clear());
+afterEach(() => MockClient.clearAll());
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-mockserver",
   "description": "Testing made easy with mocked http servers",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "MIT",
   "jest": {
     "verbose": true


### PR DESCRIPTION
This will rename `clear` to `clearAll` and make it static, so it can be called without creating a mock instance. 

This also introduces a breaking change, where the host proxy host url will have to be specified when requiring the MockClient  module.

```js
const MOCKSERVER_URI = 'localhost:3000';
const MockClient = require('../src/client/Client')(MOCKSERVER_URI);
MockClient.clearAll();
```

@Tradeshift/collaboration 