### PR TITLE
Rename "route" to "mock"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ const { MockClient } = require('http-mockserver');
 const mockServerHost = 'localhost:3000'; // Connect to MockServer on localhost:3000
 const myMockClient = new MockClient(8888, mockServerHost); // start a mockServer instance on port 8888
 
-// Setup route on localhost:8888/rest/users
-myMockClient.addRoute({
+// Setup mock on localhost:8888/rest/users
+myMockClient.addMock({
 	uri: '/rest/users',
 	method: 'GET',
 	response: {
@@ -42,8 +42,8 @@ $ http-mockserver --help
 ## Client API
 The following methods can be called on any MockClient instance
 
-#### mockClient.addRoute([options])
-Adds a new route to the mockServer. Returns a promise.
+#### mockClient.addMock([options])
+Add mock. Returns a promise.
 
 ##### Options:
 * **uri**: uri of request, eg. `/users/5345`

--- a/__tests__/mockClient.test.js
+++ b/__tests__/mockClient.test.js
@@ -5,17 +5,17 @@ const MockClient = require('../src/client/Client')(MOCKSERVER_URI);
 const MOCKED_HOST_URI = 'http://localhost:4000';
 const mockClient = new MockClient(4000);
 
-describe('when adding routes on the same uri', () => {
-	it('should return first response when route is added once', done => {
-		mockClient.addRoute({
-			uri: '/duplicate-route',
+describe('when adding mocks on the same uri', () => {
+	it('should return first mock', done => {
+		mockClient.addMock({
+			uri: '/duplicate-mock',
 			method: 'GET',
 			response: {
 				body: 'First response'
 			}
 		})
 		.then(() => {
-			return request(`${MOCKED_HOST_URI}/duplicate-route`).spread((response, body) => {
+			return request(`${MOCKED_HOST_URI}/duplicate-mock`).spread((response, body) => {
 				expect(response.statusCode).toBe(200);
 				expect(body).toBe('First response');
 			});
@@ -23,16 +23,16 @@ describe('when adding routes on the same uri', () => {
 		.then(done, done.fail);
 	});
 
-	it('should return second response when route it overwritten', done => {
-		mockClient.addRoute({
-			uri: '/duplicate-route',
+	it('should return second mock', done => {
+		mockClient.addMock({
+			uri: '/duplicate-mock',
 			method: 'GET',
 			response: {
 				body: 'Second response'
 			}
 		})
 		.then(() => {
-			return request(`${MOCKED_HOST_URI}/duplicate-route`).spread((response, body) => {
+			return request(`${MOCKED_HOST_URI}/duplicate-mock`).spread((response, body) => {
 				expect(response.statusCode).toBe(200);
 				expect(body).toBe('Second response');
 			});
@@ -42,9 +42,9 @@ describe('when adding routes on the same uri', () => {
 });
 
 describe('clean', () => {
-	it('should be possible to add a route and call it', done => {
-		// Add route
-		mockClient.addRoute({
+	it('should return a mock when it has been added', done => {
+		// Add mock
+		mockClient.addMock({
 			uri: '/test',
 			method: 'get',
 			response: {
@@ -52,7 +52,7 @@ describe('clean', () => {
 			}
 		})
 
-		// Route can be called
+		// Mock should be returned
 		.then(() => {
 			return request(`${MOCKED_HOST_URI}/test`).spread((response, body) => {
 				expect(response.statusCode).toBe(200);
@@ -62,16 +62,16 @@ describe('clean', () => {
 		.then(done, done.fail);
 	});
 
-	it('should not be possible to call the route after it has been cleared', done => {
+	it('should not return a mock after it has been cleared', done => {
 		MockClient.clearAll()
 
-		// requests are cleared
+		// Requests should be cleared
 		.then(() => mockClient.getRequests())
 		.then(res => {
 			expect(res).toEqual([]);
 		})
 
-		// Route can no longer be called
+		// Mock should not be returned
 		.then(() => {
 			request(`${MOCKED_HOST_URI}/test`)
 				.then(done.fail)

--- a/examples/dynamic-mock.js
+++ b/examples/dynamic-mock.js
@@ -1,7 +1,7 @@
 let counter = 0;
 
-module.exports = function (addRoute) {
-	addRoute({
+module.exports = function (addMock) {
+	addMock({
 		port: 2020,
 		method: 'GET',
 		uri: '/dynamic-mock-example',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-mockserver",
   "description": "Testing made easy with mocked http servers",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "license": "MIT",
   "jest": {
     "verbose": true

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -59,25 +59,25 @@ class MockClient {
 	}
 
 	allowAll () {
-		return this.addRoute({
+		return this.addMock({
 			uri: '*',
 			method: 'GET',
 			response: {}
 		});
 	}
 
-	addRoute (options) {
+	addMock (options) {
 		options.port = this.port;
-		this.log('Adding route', options);
+		this.log('Adding mock', options);
 		return req({
-			uri: '/listener/',
+			uri: '/mocks/',
 			method: 'POST',
 			json: options
 		});
 	}
 
-	addRoutes (...routes) {
-		return Q.all(routes.map(options => this.addRoute(options)));
+	addMocks (...mocks) {
+		return Q.all(mocks.map(mock => this.addMock(mock)));
 	}
 
 	sendData (options) {

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -24,7 +24,7 @@ class MockClient {
 		});
 	}
 
-	listen () {
+	addListener () {
 		return req({
 			uri: '/listener/' + this.port,
 			method: 'POST'
@@ -67,9 +67,10 @@ class MockClient {
 	}
 
 	addRoute (options) {
+		options.port = this.port;
 		this.log('Adding route', options);
 		return req({
-			uri: '/listener/' + this.port,
+			uri: '/listener/',
 			method: 'POST',
 			json: options
 		});

--- a/src/server/Listener.js
+++ b/src/server/Listener.js
@@ -30,7 +30,8 @@ class Listener {
 	}
 
 	// Add route
-	add (uri, method, options) {
+	add (options) {
+		const {uri, method} = options;
 		this.routes[uri] = this.routes[uri] || {};
 
 		// Register route if it hasn't been registered before

--- a/src/server/Listener.js
+++ b/src/server/Listener.js
@@ -19,33 +19,33 @@ class Listener {
 		console.log(`Added listener on port ${port}`);
 
 		this.port = port;
-		this.routes = {};
+		this.mocks = {};
 		this.app = app;
 		this.server = createServer(port, app);
 	}
 
-	// Get route
+	// Get mock
 	get (uri, method) {
-		return _.get(this.routes[uri], method);
+		return _.get(this.mocks[uri], method);
 	}
 
-	// Add route
+	// Add mock
 	add (options) {
 		const {uri, method} = options;
-		this.routes[uri] = this.routes[uri] || {};
+		this.mocks[uri] = this.mocks[uri] || {};
 
-		// Register route if it hasn't been registered before
-		if (!this.routes[uri][method]) {
+		// Register mock if it hasn't been registered before
+		if (!this.mocks[uri][method]) {
 			this.app[method.toLowerCase()](uri, (req, res) => {
-				return this.routes[uri][method].handler(req, res);
+				return this.mocks[uri][method].handler(req, res);
 			});
 		}
 
-		this.routes[uri][method] = {
+		this.mocks[uri][method] = {
 			options: options,
 			clients: [],
 			chunks: [],
-			handler: this.getRouteHandler(options)
+			handler: this.getMockHandler(options)
 		};
 	}
 
@@ -54,30 +54,30 @@ class Listener {
 	}
 
 	sendChunk (uri, chunk) {
-		const route = this.get(uri, 'GET');
-		if (!route) {
-			throw new Error(`Route does not exist ${this.port}/${uri}`);
+		const mock = this.get(uri, 'GET');
+		if (!mock) {
+			throw new Error(`Mock does not exist ${this.port}/${uri}`);
 		}
 
-		route.clients.forEach(client => client.write(chunk));
-		route.chunks.push(chunk);
-		console.log('Chunk sent to', reqFm(route.options.method, this.port, uri));
+		mock.clients.forEach(client => client.write(chunk));
+		mock.chunks.push(chunk);
+		console.log('Chunk sent to', reqFm(mock.options.method, this.port, uri));
 	}
 
-	getRouteHandler (options) {
+	getMockHandler (options) {
 		if (options.response) {
-			return this.getStaticRouteHandler(options);
+			return this.getStaticMockHandler(options);
 		} else if (options.handler) {
-			return this.getDynamicRouteHandler(options);
+			return this.getDynamicMockHandler(options);
 		} else if (options.proxy) {
-			return this.getProxyRouteHandler(options);
+			return this.getProxyMockHandler(options);
 		} else {
-			return this.getStreamingRouteHandler(options);
+			return this.getStreamingMockHandler(options);
 		}
 	}
 
 	// Returns static response
-	getStaticRouteHandler (options) {
+	getStaticMockHandler (options) {
 		const {uri, response, method} = options;
 		const statusCode = response.statusCode || 200;
 		console.log(reqFm(method, this.port, uri), '(static)');
@@ -89,7 +89,7 @@ class Listener {
 	}
 
 	// Returns dynamic handler that can change the response depending on the request
-	getDynamicRouteHandler (options) {
+	getDynamicMockHandler (options) {
 		const { uri, method, handler } = options;
 		console.log(reqFm(method, this.port, uri), '(dynamic)');
 		return (req, res) => {
@@ -98,8 +98,8 @@ class Listener {
 		};
 	}
 
-	// Proxies the request to another route
-	getProxyRouteHandler (options) {
+	// Proxies the request to another mock
+	getProxyMockHandler (options) {
 		const srcPort = this.port;
 		const { uri, method } = options;
 		const targetPort = options.proxy.target.substring(options.proxy.target.lastIndexOf(':') + 1);
@@ -117,24 +117,24 @@ class Listener {
 	}
 
 	// Returns a "keep-alive" response which can transport chunked responses
-	getStreamingRouteHandler (options) {
+	getStreamingMockHandler (options) {
 		const { uri, method } = options;
 
 		console.log(reqFm(method, this.port, uri), '(streaming)');
 		return (req, res) => {
 			requestLogService.setEntryType(req.id, 'streaming');
-			const route = this.get(uri, method);
-			req.on('close', () => _.pull(route.clients, res)); // Remove listener
-			route.clients.push(res); // Add listener
-			route.chunks.forEach(chunk => res.write(chunk)); // Replay buffered chunks
+			const mock = this.get(uri, method);
+			req.on('close', () => _.pull(mock.clients, res)); // Remove listener
+			mock.clients.push(res); // Add listener
+			mock.chunks.forEach(chunk => res.write(chunk)); // Replay buffered chunks
 		};
 	}
 
 	toString () {
-		return _.mapValues(this.routes, (routes, uri) => {
-			return _.mapValues(routes, (route, method) => {
-				route.clientsCount = route.clients.length;
-				return _.omit(route, 'clients');
+		return _.mapValues(this.mocks, (mocks, uri) => {
+			return _.mapValues(mocks, (mock, method) => {
+				mock.clientsCount = mock.clients.length;
+				return _.omit(mock, 'clients');
 			});
 		});
 	}

--- a/src/server/controller.js
+++ b/src/server/controller.js
@@ -9,9 +9,9 @@ controller.addListener = (req, res) => {
 	res.sendStatus(200);
 };
 
-controller.addRoute = (req, res) => {
+controller.addMock = (req, res) => {
 	const options = req.body;
-	listenerService.addRoute(options);
+	listenerService.addMock(options);
 	res.sendStatus(200);
 };
 

--- a/src/server/controller.js
+++ b/src/server/controller.js
@@ -3,16 +3,15 @@ const listenerService = require('./listenerService');
 const requestLogService = require('./requestLogService');
 const controller = {};
 
-controller.addListenerOrRoute = (req, res) => {
+controller.addListener = (req, res) => {
 	const port = req.params.port;
+	listenerService.addListener(port);
+	res.sendStatus(200);
+};
+
+controller.addRoute = (req, res) => {
 	const options = req.body;
-
-	if (_.isEmpty(options)) {
-		listenerService.addListener(port);
-	} else {
-		listenerService.addRoute(port, options);
-	}
-
+	listenerService.addRoute(options);
 	res.sendStatus(200);
 };
 

--- a/src/server/expressServer.js
+++ b/src/server/expressServer.js
@@ -6,7 +6,8 @@ const bodyParser = require('body-parser');
 app.use(bodyParser.json());
 const controller = require('./controller');
 
-app.post('/listener/:port', controller.addListenerOrRoute);
+app.post('/listener/:port', controller.addListener);
+app.post('/listener', controller.addRoute);
 app.delete('/listener/:port', controller.removeListener);
 
 app.post('/listener/:port/chunk', controller.sendChunk);

--- a/src/server/expressServer.js
+++ b/src/server/expressServer.js
@@ -7,10 +7,10 @@ app.use(bodyParser.json());
 const controller = require('./controller');
 
 app.post('/listener/:port', controller.addListener);
-app.post('/listener', controller.addRoute);
 app.delete('/listener/:port', controller.removeListener);
-
 app.post('/listener/:port/chunk', controller.sendChunk);
+
+app.post('/mocks', controller.addMock);
 
 app.get('/listener/:port?', controller.getListeners);
 app.delete('/clear', controller.clear);

--- a/src/server/listenerService.js
+++ b/src/server/listenerService.js
@@ -21,13 +21,10 @@ listenerService.addListener = function (port) {
 	return listener;
 };
 
-listenerService.addRoute = function (port, options) {
-	if (!options.method) {
-		throw new Error(`"method" required. port=${port} uri=${options.uri}`);
-	}
-
-	if (!options.uri) {
-		throw new Error(`"uri" required. port=${port}`);
+listenerService.addRoute = function (options) {
+	const port = options.port;
+	if (!options.port || !options.method || !options.uri) {
+		throw new Error(`"port", "method" and "uri" required. options=${options}`);
 	}
 
 	const listener = listeners[port] || listenerService.addListener(port);
@@ -36,7 +33,7 @@ listenerService.addRoute = function (port, options) {
 		console.log(`Overwriting route: ${options.method} http://localhost:${port}${options.uri}`);
 	}
 
-	listener.add(options.uri, options.method, options);
+	listener.add(options);
 };
 
 listenerService.removeListener = function (port) {

--- a/src/server/listenerService.js
+++ b/src/server/listenerService.js
@@ -21,16 +21,16 @@ listenerService.addListener = function (port) {
 	return listener;
 };
 
-listenerService.addRoute = function (options) {
+listenerService.addMock = function (options) {
 	const port = options.port;
 	if (!options.port || !options.method || !options.uri) {
 		throw new Error(`"port", "method" and "uri" required. options=${options}`);
 	}
 
 	const listener = listeners[port] || listenerService.addListener(port);
-	const hasRoute = listener.get(options.uri, options.method);
-	if (hasRoute) {
-		console.log(`Overwriting route: ${options.method} http://localhost:${port}${options.uri}`);
+	const hasMock = listener.get(options.uri, options.method);
+	if (hasMock) {
+		console.log(`Overwriting mock: ${options.method} http://localhost:${port}${options.uri}`);
 	}
 
 	listener.add(options);

--- a/src/server/mockFileReader.js
+++ b/src/server/mockFileReader.js
@@ -46,7 +46,7 @@ function parseJsonFile (filename, mockConfigs) {
 	mockConfigs = Array.isArray(mockConfigs) ? mockConfigs : [mockConfigs];
 
 	try {
-		mockConfigs.map(listenerService.addRoute);
+		mockConfigs.map(listenerService.addMock);
 	} catch (e) {
 		console.log(`Error parsing ${filename}`, e);
 	}
@@ -54,7 +54,7 @@ function parseJsonFile (filename, mockConfigs) {
 
 function parseJsFile (filename, handler) {
 	try {
-		return handler(listenerService.addRoute);
+		return handler(listenerService.addMock);
 	} catch (e) {
 		console.log(`Error parsing ${filename}`, e);
 	}

--- a/src/server/mockFileReader.js
+++ b/src/server/mockFileReader.js
@@ -46,7 +46,7 @@ function parseJsonFile (filename, mockConfigs) {
 	mockConfigs = Array.isArray(mockConfigs) ? mockConfigs : [mockConfigs];
 
 	try {
-		mockConfigs.map(addRoute);
+		mockConfigs.map(listenerService.addRoute);
 	} catch (e) {
 		console.log(`Error parsing ${filename}`, e);
 	}
@@ -54,14 +54,10 @@ function parseJsonFile (filename, mockConfigs) {
 
 function parseJsFile (filename, handler) {
 	try {
-		return handler(addRoute);
+		return handler(listenerService.addRoute);
 	} catch (e) {
 		console.log(`Error parsing ${filename}`, e);
 	}
-}
-
-function addRoute (mockConfig) {
-	return listenerService.addRoute(mockConfig.port, mockConfig);
 }
 
 mockFileReader.addMocks = function (filePaths = []) {


### PR DESCRIPTION
Replacing all instances of "route" with "mock". So "addRoute" -> "addMock" etc..
This is a breaking change, and will require clients to a simple search/replace. 

@Tradeshift/collaboration 