### PR TITLE
Add support for Express-style path matching on mock uris

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+end_of_line = lf
+charset = utf-8
+indent_style = tab

--- a/__tests__/examples.test.js
+++ b/__tests__/examples.test.js
@@ -9,7 +9,28 @@ describe('examples', () => {
 	it('static mock', done => {
 		return request('http://localhost:2021/static-mock-example', {json: true}).spread((response, body) => {
 			expect(response.statusCode).toBe(200);
+			expect(response.headers['content-type']).toMatch(/application\/json/);
 			expect(body).toEqual({someKey: 'some value'});
+		})
+		.then(done, done.fail);
+	});
+
+	it('should return text response with placeholders replaced', done => {
+		return request('http://localhost:2021/static-mock-with-params-example/sqren', {json: true}).spread((response, body) => {
+			expect(response.statusCode).toBe(200);
+			expect(response.headers['content-type']).toMatch(/text\/html/);
+			expect(body).toEqual('My name is sqren');
+		})
+		.then(done, done.fail);
+	});
+
+	it('should return json response with placeholders replaced', done => {
+		return request('http://localhost:2021/static-mock-with-params-json-example/sqren', {json: true}).spread((response, body) => {
+			expect(response.statusCode).toBe(200);
+			expect(response.headers['content-type']).toMatch(/application\/json/);
+			expect(body).toEqual({
+				name: 'sqren'
+			});
 		})
 		.then(done, done.fail);
 	});

--- a/__tests__/listener.test.js
+++ b/__tests__/listener.test.js
@@ -1,0 +1,92 @@
+const Listener = require('../src/server/Listener');
+
+describe('listener', () => {
+	let listener;
+	beforeEach(() => {
+		listener = new Listener(3001);
+	});
+
+	afterEach(() => {
+		listener.destroy();
+	});
+
+	it('should match paths without tokens', () => {
+		const tokenlessPath = '/path/without/tokens';
+		listener.add({
+			method: 'GET',
+			response: { body: 'a' },
+			uri: tokenlessPath
+		});
+		const result = listener.get(tokenlessPath, 'GET');
+		expect(result.options.uri).toBe(tokenlessPath);
+		expect(result.options.response.body).toBe('a');
+	});
+
+	it('should match paths with a single token', () => {
+		const tokenPath = '/path/:with/tokens';
+		listener.add({
+			method: 'GET',
+			response: { body: 'b' },
+			uri: tokenPath
+		});
+		const result = listener.get('/path/alpha/tokens', 'GET');
+		expect(result.options.uri).toBe(tokenPath);
+		expect(result.options.response.body).toBe('b');
+	});
+
+	it('should match paths with multiple tokens', () => {
+		const tokenPath = '/path/:with/tokens/:and/so/:much/other/:stuff';
+		listener.add({
+			method: 'GET',
+			response: { body: 'c' },
+			uri: tokenPath
+		});
+		const result = listener.get('/path/first/tokens/second/so/third/other/fourth', 'GET');
+		expect(result.options.uri).toBe(tokenPath);
+		expect(result.options.response.body).toBe('c');
+	});
+
+	it('should not do partial token matching', () => {
+		const tokenPath = '/path/:with/tokens/:and/:stuff';
+		listener.add({
+			method: 'GET',
+			response: { body: 'd' },
+			uri: tokenPath
+		});
+		const result = listener.get('/path/first/tokens/second', 'GET');
+		expect(result).toBeUndefined();
+	});
+
+	it('should do partial token matching', () => {
+		const tokenPath = '/path/:with/tokens/:and/:stuff?';
+		listener.add({
+			method: 'GET',
+			response: { body: 'd' },
+			uri: tokenPath
+		});
+		const result = listener.get('/path/first/tokens/second', 'GET');
+		expect(result.options.uri).toBe(tokenPath);
+		expect(result.options.response.body).toBe('d');
+	});
+
+	it('should match the uri method on paths with tokens', () => {
+		const tokenPath = '/path/:with/tokens/:and/:stuff';
+		listener.add({
+			method: 'DEL',
+			response: {},
+			uri: tokenPath
+		});
+		listener.add({
+			method: 'GET',
+			response: { body: 'e' },
+			uri: tokenPath
+		});
+		listener.add({
+			method: 'PUT',
+			response: {},
+			uri: tokenPath
+		});
+		const result = listener.get('/path/first/tokens/second/third', 'GET');
+		expect(result.options.response.body).toBe('e');
+	});
+});

--- a/examples/dynamic-mock.js
+++ b/examples/dynamic-mock.js
@@ -1,6 +1,7 @@
 let counter = 0;
 
 module.exports = function (addMock) {
+	// Simple mock with counter
 	addMock({
 		port: 2020,
 		method: 'GET',
@@ -8,6 +9,18 @@ module.exports = function (addMock) {
 		handler: function (req, res) {
 			counter++;
 			res.send(`Counter: ${counter}`);
+		}
+	});
+
+	// Parameterized mock
+	addMock({
+		port: 2020,
+		method: 'GET',
+		uri: '/dynamic-parameterized-example/:name',
+		handler: function (req, res) {
+			res.send({
+				Name: `${req.params.name}`
+			});
 		}
 	});
 };

--- a/examples/parameterize-example.json
+++ b/examples/parameterize-example.json
@@ -1,0 +1,8 @@
+{
+	"port": 2021,
+	"method": "GET",
+	"uri": "/parameterized-example/:name",
+	"response": {
+		"body": "My name is ${req.params.name}"
+	}
+}

--- a/examples/static-mock.json
+++ b/examples/static-mock.json
@@ -1,4 +1,4 @@
-{
+[{
 	"port": 2021,
 	"method": "GET",
 	"uri": "/static-mock-example",
@@ -11,4 +11,22 @@
 			"someKey": "some value"
 		}
 	}
-}
+},
+{
+	"port": 2021,
+	"method": "GET",
+	"uri": "/static-mock-with-params-example/:name",
+	"response": {
+		"body": "My name is ${req.params.name}"
+	}
+},
+{
+	"port": 2021,
+	"method": "GET",
+	"uri": "/static-mock-with-params-json-example/:name",
+	"response": {
+		"body": {
+			"name": "${req.params.name}"
+		}
+	}
+}]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express": "4.14.0",
     "http-proxy": "1.16.2",
     "lodash": "4.17.4",
+    "path-to-regexp": "1.7.0",
     "q": "1.4.1",
     "recursive-readdir": "2.1.0",
     "request": "2.79.0",

--- a/src/server/Listener.js
+++ b/src/server/Listener.js
@@ -5,6 +5,7 @@ const express = require('express');
 const http = require('http');
 const httpProxy = require('http-proxy');
 const requestLogService = require('./requestLogService');
+const logService = require('./logService');
 
 class Listener {
 	// Create new listener
@@ -16,7 +17,7 @@ class Listener {
 			next();
 		});
 
-		console.log(`Added listener on port ${port}`);
+		logService.info(`Added listener on port ${port}`);
 
 		this.port = port;
 		this.mocks = {};
@@ -61,7 +62,7 @@ class Listener {
 
 		mock.clients.forEach(client => client.write(chunk));
 		mock.chunks.push(chunk);
-		console.log('Chunk sent to', reqFm(mock.options.method, this.port, uri));
+		logService.info('Chunk sent to', reqFm(mock.options.method, this.port, uri));
 	}
 
 	getMockHandler (options) {
@@ -80,7 +81,7 @@ class Listener {
 	getStaticMockHandler (options) {
 		const {uri, response, method} = options;
 		const statusCode = response.statusCode || 200;
-		console.log(reqFm(method, this.port, uri), '(static)');
+		logService.info(reqFm(method, this.port, uri), '(static)');
 		return (req, res) => {
 			requestLogService.setEntryType(req.id, 'static');
 			res.set(response.headers);
@@ -91,7 +92,7 @@ class Listener {
 	// Returns dynamic handler that can change the response depending on the request
 	getDynamicMockHandler (options) {
 		const { uri, method, handler } = options;
-		console.log(reqFm(method, this.port, uri), '(dynamic)');
+		logService.info(reqFm(method, this.port, uri), '(dynamic)');
 		return (req, res) => {
 			requestLogService.setEntryType(req.id, 'dynamic');
 			return handler(req, res);
@@ -105,11 +106,11 @@ class Listener {
 		const targetPort = options.proxy.target.substring(options.proxy.target.lastIndexOf(':') + 1);
 		const proxy = httpProxy.createProxyServer(options.proxy);
 
-		console.log(`${reqFm(method, srcPort, uri)} -> ${reqFm(method, targetPort, uri)}`, '(proxy)');
+		logService.info(`${reqFm(method, srcPort, uri)} -> ${reqFm(method, targetPort, uri)}`, '(proxy)');
 		return (req, res) => {
 			requestLogService.setEntryType(req.id, 'proxy');
 			proxy.web(req, res, e => {
-				console.error(e);
+				logService.error(e);
 				res.statusCode = 500;
 				res.end(e.message);
 			});
@@ -120,7 +121,7 @@ class Listener {
 	getStreamingMockHandler (options) {
 		const { uri, method } = options;
 
-		console.log(reqFm(method, this.port, uri), '(streaming)');
+		logService.info(reqFm(method, this.port, uri), '(streaming)');
 		return (req, res) => {
 			requestLogService.setEntryType(req.id, 'streaming');
 			const mock = this.get(uri, method);

--- a/src/server/expressServer.js
+++ b/src/server/expressServer.js
@@ -2,6 +2,7 @@ const express = require('express');
 const http = require('http');
 const app = express();
 const bodyParser = require('body-parser');
+const logService = require('./logService');
 
 app.use(bodyParser.json());
 const controller = require('./controller');
@@ -18,7 +19,7 @@ app.delete('/clear', controller.clear);
 app.get('/requests/:port?', controller.getRequestLogs);
 
 app.use((err, req, res, next) => {
-	console.error(err.stack);
+	logService.error(err.stack);
 	res.status(400).send(err.message);
 });
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,6 +2,7 @@ const Q = require('q');
 const listenerService = require('./listenerService');
 const expressServer = require('./expressServer');
 const mockFileReader = require('./mockFileReader');
+const logService = require('./logService');
 
 const mockServer = {};
 const promises = [];
@@ -9,7 +10,7 @@ const promises = [];
 mockServer.start = (port = 3000) => {
 	const promise = Q.Promise((resolve) => {
 		expressServer.listen(port, () => {
-			console.log(`Running http-mockserver on http://localhost:${port}`);
+			logService.info(`Running http-mockserver on http://localhost:${port}`);
 			resolve();
 		});
 	});

--- a/src/server/listenerService.js
+++ b/src/server/listenerService.js
@@ -1,4 +1,5 @@
 const Listener = require('./Listener');
+const logService = require('./logService');
 
 const listeners = {};
 const listenerService = {};
@@ -30,7 +31,7 @@ listenerService.addMock = function (options) {
 	const listener = listeners[port] || listenerService.addListener(port);
 	const hasMock = listener.get(options.uri, options.method);
 	if (hasMock) {
-		console.log(`Overwriting mock: ${options.method} http://localhost:${port}${options.uri}`);
+		logService.info(`Overwriting mock: ${options.method} http://localhost:${port}${options.uri}`);
 	}
 
 	listener.add(options);
@@ -43,7 +44,7 @@ listenerService.removeListener = function (port) {
 
 	listeners[port].destroy();
 	delete listeners[port];
-	console.log('Removed listener for', port);
+	logService.info('Removed listener for', port);
 };
 
 listenerService.sendChunk = function (port, uri, chunk) {

--- a/src/server/logService.js
+++ b/src/server/logService.js
@@ -1,0 +1,13 @@
+function isTestEnv () {
+	return process.env.NODE_ENV === 'test';
+}
+
+module.exports = {
+	error: (...args) => {
+		console.error(...args);
+	},
+	info: (...args) => {
+		if (isTestEnv()) return;
+		console.info(...args);
+	}
+};

--- a/src/server/mockFileReader.js
+++ b/src/server/mockFileReader.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const readDir = require('recursive-readdir');
 const listenerService = require('./listenerService.js');
+const logService = require('./logService');
 
 const mockFileReader = {};
 
@@ -30,7 +31,7 @@ function getFile (filename) {
 			content: require(path.resolve(filename))
 		};
 	} catch (e) {
-		console.log(`Error loading ${filename}`, e);
+		logService.info(`Error loading ${filename}`, e);
 		throw e;
 	}
 }
@@ -48,7 +49,7 @@ function parseJsonFile (filename, mockConfigs) {
 	try {
 		mockConfigs.map(listenerService.addMock);
 	} catch (e) {
-		console.log(`Error parsing ${filename}`, e);
+		logService.info(`Error parsing ${filename}`, e);
 	}
 }
 
@@ -56,7 +57,7 @@ function parseJsFile (filename, handler) {
 	try {
 		return handler(listenerService.addMock);
 	} catch (e) {
-		console.log(`Error parsing ${filename}`, e);
+		logService.info(`Error parsing ${filename}`, e);
 	}
 }
 
@@ -75,7 +76,7 @@ mockFileReader.addMocks = function (filePaths = []) {
 				return files.map(file => parseFile(file.name, file.content));
 			})
 			.catch(err => {
-				console.log(`Error loading files ${filePath}`, err);
+				logService.info(`Error loading files ${filePath}`, err);
 			});
 	});
 

--- a/src/server/requestLogService.js
+++ b/src/server/requestLogService.js
@@ -1,5 +1,6 @@
 const uuid = require('uuid/v4');
 const _ = require('lodash');
+const logService = require('./logService');
 
 const entries = [];
 const service = {};
@@ -33,7 +34,7 @@ service.addEntry = function (req, res) {
 			body: _.toString(args[0])
 		};
 
-		console.log(reqFm(req.method, entry.req.port, req.originalUrl, res.statusCode));
+		logService.info(reqFm(req.method, entry.req.port, req.originalUrl, res.statusCode));
 		endHandler.apply(res, args);
 	};
 };


### PR DESCRIPTION
Our register flow creates a company and sets a company property. We don't know what the UUID for the company will be at the time we need to define the mock URI. This enables express-style path matching on mock URIs so we can define more specific URIs.

I'd actually like to somehow get the path params back from the client somehow, but let's start with this first.

Usage example:
```
const PROPERTY_KEY = 'some-key';
backendService.addMock({
  method: 'PUT',
  uri: `/tradeshift-backend/rest/companies/register/:companyId`,
  response: {
    body: {
      Token: uuid(),
    },
  },
}),
backendService.addMock({
  method: 'PUT',
  // prior to this PR, `/tradeshift-backend/rest/external/companies/*` did work, but would grab too much in practice
  uri: `/tradeshift-backend/rest/external/companies/:companyId/properties/${PROPERTY_KEY}`,
  response: {},
}),
```

@sqren 