### PR TITLE
COL-575 Remove addMocks from client side

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-mockserver",
   "description": "Testing made easy with mocked http servers",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "jest": {
     "verbose": false,

--- a/src/both/MockServerFactory.js
+++ b/src/both/MockServerFactory.js
@@ -33,10 +33,6 @@ class MockServerFactory {
 		return this.service.addMock(options);
 	}
 
-	addMocks (...args) {
-		return this.addMocks(...args);
-	}
-
 	sendData (options) {
 		return this.service.sendData(this.port, options);
 	}

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -66,10 +66,6 @@ clientService.addMock = function (options) {
 	});
 };
 
-clientService.addMocks = function (...mocks) {
-	return Q.all(mocks.map(clientService.addMock));
-};
-
 clientService.sendData = function (port, options) {
 	return req({
 		uri: '/listener/' + port + '/chunk',


### PR DESCRIPTION
There was a bug on `addMocks` that it didn't set up the port for each mock. In order to use `addMocks` properly you have to put `port` explicitly in options, which is inconsistent with `addMock` usage.

Instead of fixing this, I chose to remove it because it would be fairly easier for the consumer to use `addMock` and iterate it themselves.

Please have a look. Thanks. @Tradeshift/collaboration  